### PR TITLE
Bugfixes after presentation

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class AppController {
+  constructor() {}
+
+  @Get()
+  backendCheck(): string {
+    return 'Working fine';
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
 import { ShapeModule } from './shape/shape.module';
 import { FileModule } from './file/file.module';
 import { ConsoleModule } from 'nestjs-console';
@@ -7,7 +8,7 @@ import { CliModule } from './cli/cli.module';
 
 @Module({
   imports: [ConsoleModule, ShapeModule, FileModule, CliModule],
-  controllers: [],
+  controllers: [AppController],
   providers: [FileService],
 })
 export class AppModule {}

--- a/backend/src/shape/dto/create-shape.dto.ts
+++ b/backend/src/shape/dto/create-shape.dto.ts
@@ -38,12 +38,16 @@ export class ShapeDto extends BaseShapeDto {
   targetClass: string;
   memorixCompatible: boolean;
   comment: string;
+  closed: boolean;
+  ignoredProperties: string[];
   constructor(bodyValue: any = {}) {
     super(bodyValue);
     this.identifier = bodyValue.identifier;
     this.targetClass = bodyValue.targetClass;
     this.memorixCompatible = bodyValue.memorixCompatible;
     this.comment = bodyValue.comment;
+    this.closed = bodyValue.closed;
+    this.ignoredProperties = bodyValue.ignoredProperties;
   }
 }
 

--- a/backend/src/shape/generate-shape/generate-shape.service.ts
+++ b/backend/src/shape/generate-shape/generate-shape.service.ts
@@ -28,6 +28,7 @@ export class GenerateShapeService {
 
   async create(createShapeDto: CreateShapeDto) {
     const self = this;
+    this.prefixes = {};
 
     this.createShapeDto = createShapeDto;
 

--- a/backend/src/shape/generate-shape/generate-shape.service.ts
+++ b/backend/src/shape/generate-shape/generate-shape.service.ts
@@ -164,8 +164,21 @@ export class GenerateShapeService {
     );
     ignoreOld.push(this.prefixes['dc'] + 'identifier');
 
-    this.addLiteral(this.prefixes['sh'] + 'closed', true);
-    ignoreOld.push(this.prefixes['sh'] + 'closed');
+    if(this.createShapeDto.shape.closed === true || self.createShapeDto.shape.memorixCompatible === true) {
+      this.addLiteral(this.prefixes['sh'] + 'closed', true);
+    }
+
+    if(this.createShapeDto.shape.ignoredProperties.length > 0) {
+      Object.keys(this.createShapeDto.shape.ignoredProperties).forEach(key => {
+        this.createShapeDto.shape.ignoredProperties[key] = namedNode(this.shorthandToFullUrl(this.createShapeDto.shape.ignoredProperties[key]));
+      });
+    }
+    this.writer.addQuad(
+      namedNode(this.createShapeDto.shape.id),
+      namedNode(this.prefixes['sh'] + 'ignoredProperties'),
+      self.writer.list(this.createShapeDto.shape.ignoredProperties),
+    );
+    ignoreOld.push(this.prefixes['sh'] + 'ignoredProperties');
 
     ignoreOld.push(this.prefixes['sh'] + 'property');
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -16,20 +16,38 @@
       </div>
     </nav>
     <div class="page-content">
-      <router-view/>
+      <router-view v-if="backendOnline"/>
+      <backend-error v-if="!backendOnline"/>
     </div>
   </div>
 </template>
 <script lang="ts">
   import {defineComponent} from "vue";
+  import BackendError from "@/components/BackendError.vue";
+  import axios from "axios";
+  import {server} from "@/helper";
 
   export default defineComponent({
+    components: {
+      BackendError
+    },
     data() {
       return {
+        backendOnline:true,
         currentRoute: window.location.pathname
       }
     },
+    beforeMount() {
+      this.checkConnectionBackend();
+    },
     methods: {
+      checkConnectionBackend() {
+        axios.get(encodeURI(server.baseURL)).then(() => {
+          this.backendOnline = true;
+        }).catch(e => {
+          this.backendOnline = false;
+        });
+      },
       isActiveMenu(menu:string):string {
         if(this.currentRoute.substr(1,menu.length) === menu) {
           return ' active';

--- a/frontend/src/components/BackendError.vue
+++ b/frontend/src/components/BackendError.vue
@@ -2,7 +2,7 @@
   <div class=" home container">
     <div class="row justify-content-md-center">
       <div class="col-12">
-        <message :msg="$t('welcome')"/>
+        <message :msg="$t('backendOff')"/>
       </div>
     </div>
   </div>
@@ -13,14 +13,9 @@
   import Message from '@/components/Message.vue'
 
   export default {
-    name: 'Home',
+    name: 'BackendError',
     components: {
       Message
     }
   }
 </script>
-<style lang="scss">
-  .home {
-    text-align:center;
-  }
-</style>

--- a/frontend/src/components/Message.vue
+++ b/frontend/src/components/Message.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="home">
+  <div>
     <h1>{{ msg }}</h1>
     <img alt="LDShapes logo" src="../../public/images/ldshapes-blue.svg" class="logo">
   </div>

--- a/frontend/src/components/shape/Create.vue
+++ b/frontend/src/components/shape/Create.vue
@@ -57,8 +57,8 @@
   import { Form } from 'vee-validate';
   import config from '../../../../resources/shapes/config.json';
 
-  import { UpdateSettingFieldFunction, AddSettingRowFunction, RemoveSettingRowFunction, GetFullIriFunction } from "@/types/shape";
-  import { updateSettingFieldKey, addSettingRowKey, removeSettingRowKey, getFullIriKey } from "@/symbols/shape";
+  import { UpdateSettingFieldFunction, AddSettingRowFunction, RemoveSettingRowFunction, GetFullIriFunction, GetShorthandFromFullIriFunction } from "@/types/shape";
+  import { updateSettingFieldKey, addSettingRowKey, removeSettingRowKey, getFullIriKey, getShorthandFromFullIriKey } from "@/symbols/shape";
 
   export default defineComponent({
     name: 'ShapeCreate',
@@ -157,6 +157,26 @@
         return iri;
       }
 
+      const getShorthandFromFullIri: GetShorthandFromFullIriFunction = function (iri :string) {
+        if(iri === undefined){
+          return iri;
+        }
+        let newIri = iri;
+        let prevPrefix = '';
+        let prevLength = 0;
+        Object.keys(settingsObject['prefix']).forEach(number => {
+          const key :any = number;
+          const id :string = settingsObject['prefix'][key]['id'];
+          const prefix :string = settingsObject['prefix'][key]['prefix'];
+          if(id === iri.substr(0,id.length) && (prevPrefix === '' || prevPrefix === 'self'  || id.length > prevLength)) {
+            newIri = prefix + ':' + iri.substr(id.length);
+            prevPrefix = prefix;
+            prevLength = id.length;
+          }
+        });
+        return newIri;
+      }
+
       provide("settings", settingsObject);
       provide("generalConfig", generalConfig);
       provide("shapeConfig", config);
@@ -164,6 +184,7 @@
       provide(addSettingRowKey, addSettingRow);
       provide(removeSettingRowKey, removeSettingRow);
       provide(getFullIriKey, getFullIri);
+      provide(getShorthandFromFullIriKey, getShorthandFromFullIri);
 
       return {
         settingsObject,

--- a/frontend/src/components/shape/Create.vue
+++ b/frontend/src/components/shape/Create.vue
@@ -39,6 +39,7 @@
                 <title-modal :title="$t('ChangeTitle')"/>
                 <label-modal :title="$t('AddLabel')"/>
                 <prefix-modal />
+                <ignored-properties-modal />
             </Form>
         </div>
     </div>
@@ -54,6 +55,7 @@
   import TitleModal from './modal/TitleModal.vue';
   import LabelModal from './modal/LabelModal.vue';
   import PrefixModal from './modal/PrefixModal.vue';
+  import IgnoredPropertiesModal from './modal/IgnoredPropertiesModal.vue';
   import { Form } from 'vee-validate';
   import config from '../../../../resources/shapes/config.json';
 
@@ -69,6 +71,7 @@
       TitleModal,
       LabelModal,
       PrefixModal,
+      IgnoredPropertiesModal,
       Form },
     data() {
       return {

--- a/frontend/src/components/shape/field/IdField.vue
+++ b/frontend/src/components/shape/field/IdField.vue
@@ -37,9 +37,6 @@
         type: String,
         default: 'id'
       },
-      value: {
-        type: String,
-      },
       inline: {
         type: Boolean,
         default: true
@@ -48,7 +45,7 @@
     data() {
       const prefixesCC: { [key: string]: any[] } = {};
       return {
-        field_value:this.value,
+        field_value:'',
         prefixesCC,
         prefixId:'',
         savedPrefix:false,
@@ -56,25 +53,24 @@
       }
     },
     watch: {
+      field: {
+        handler() {
+          this.field_value = '';
+          setTimeout(()=>{
+            this.setFieldValue(this.field);
+          },200)
+        },
+      },
       settings: {
-        handler(newVal:any) {
-          var pList = this.field.split('.');
-          var len = pList.length;
-          for(var i = 0; i < len-1; i++) {
-            var elem = pList[i];
-            if( !newVal[elem] ) newVal[elem] = {}
-            newVal = newVal[elem];
-          }
-          this.field_value = this.getShorthandFromFullUrl(newVal[pList[len-1]]);
+        handler() {
+          this.setFieldValue(this.field);
         },
         deep:true,
       },
     },
     mounted() {
       this.setPrefixes();
-      if(this.field_value !== undefined) {
-        this.field_value = this.getShorthandFromFullUrl(this.field_value);
-      }
+      this.setFieldValue(this.field);
     },
     setup() {
       const settings :any = inject('settings');
@@ -93,6 +89,17 @@
     },
     methods: {
       validateAbsoluteIRI,
+      setFieldValue(field :string) {
+        var pList = field.split('.');
+        var newVal = this.settings;
+        var len = pList.length;
+        for(var i = 0; i < len-1; i++) {
+          var elem = pList[i];
+          if( !newVal[elem] ) newVal[elem] = {}
+          newVal = newVal[elem];
+        }
+        this.field_value = this.getShorthandFromFullUrl(newVal[pList[len-1]]);
+      },
       checkForValidPrefixes() {
         if(this.field_value !== undefined) {
           const matches: string[]|null = this.field_value.match(/^([a-z][a-z0-9]+):[a-zA-Z]/);

--- a/frontend/src/components/shape/field/IdField.vue
+++ b/frontend/src/components/shape/field/IdField.vue
@@ -20,7 +20,7 @@
   import axios from "axios";
   import {validateAbsoluteIRI} from '@/mixins/validateShape';
   import { ErrorMessage, Field } from 'vee-validate';
-  import {updateSettingFieldKey, getFullIriKey} from "@/symbols/shape";
+  import {updateSettingFieldKey, getFullIriKey, addSettingRowKey, getShorthandFromFullIriKey} from "@/symbols/shape";
 
   export default defineComponent({
     name: 'IdField',
@@ -191,24 +191,6 @@
             });
           }
         }
-      },
-      getShorthandFromFullUrl(url :string) {
-        if(url === undefined){
-          return url;
-        }
-        let newUrl = url;
-        let prevPrefix = '';
-        let prevLength = 0;
-        Object.keys(this.settings['prefix']).forEach(key => {
-          const id = this.settings['prefix'][key]['id'];
-          const prefix = this.settings['prefix'][key]['prefix'];
-          if(id === url.substr(0,id.length) && (prevPrefix === '' || prevPrefix === 'self'  || id.length > prevLength)) {
-            newUrl = prefix + ':' + url.substr(id.length);
-            prevPrefix = prefix;
-            prevLength = id.length;
-          }
-        });
-        return newUrl;
       },
     },
   });

--- a/frontend/src/components/shape/field/IdField.vue
+++ b/frontend/src/components/shape/field/IdField.vue
@@ -172,15 +172,15 @@
           });
           //and change the paths for all properties and groups that need changing.
           Object.keys(this.settings['group']).forEach(key => {
-            if(this.settings['group'][key]['id'].substr(0,this.oldId.length)) {
+            if(this.settings['group'][key]['id'].substr(0,this.oldId.length) === this.oldId) {
               this.settings['group'][key]['id'] = fullUrl + this.settings['group'][key]['id'].substr(this.oldId.length);
             }
           });
           Object.keys(this.settings['property']).forEach(key => {
-            if(this.settings['property'][key]['path'].substr(0,this.oldId.length)) {
+            if(this.settings['property'][key]['path'].substr(0,this.oldId.length) === this.oldId) {
               this.settings['property'][key]['path'] = fullUrl + this.settings['property'][key]['path'].substr(this.oldId.length);
             }
-            if(this.settings['property'][key]['group'] !== undefined && this.settings['property'][key]['group'].substr(0,this.oldId.length)) {
+            if(this.settings['property'][key]['group'] !== undefined && this.settings['property'][key]['group'].substr(0,this.oldId.length) === this.oldId) {
               this.settings['property'][key]['group'] = fullUrl + this.settings['property'][key]['group'].substr(this.oldId.length);
             }
           });

--- a/frontend/src/components/shape/field/IdField.vue
+++ b/frontend/src/components/shape/field/IdField.vue
@@ -58,18 +58,14 @@
     watch: {
       settings: {
         handler(newVal:any) {
-          this.field_value = '';
-          //wait a second to make sure all requested field names are up to date.
-          setTimeout(()=>{
-            var pList = this.field.split('.');
-            var len = pList.length;
-            for(var i = 0; i < len-1; i++) {
-              var elem = pList[i];
-              if( !newVal[elem] ) newVal[elem] = {}
-              newVal = newVal[elem];
-            }
-            this.field_value = this.getShorthandFromFullUrl(newVal[pList[len-1]]);
-          },500);
+          var pList = this.field.split('.');
+          var len = pList.length;
+          for(var i = 0; i < len-1; i++) {
+            var elem = pList[i];
+            if( !newVal[elem] ) newVal[elem] = {}
+            newVal = newVal[elem];
+          }
+          this.field_value = this.getShorthandFromFullUrl(newVal[pList[len-1]]);
         },
         deep:true,
       },

--- a/frontend/src/components/shape/modal/IgnoredPropertiesModal.vue
+++ b/frontend/src/components/shape/modal/IgnoredPropertiesModal.vue
@@ -1,0 +1,52 @@
+<template>
+    <div class="modal fade" id="ignoredPropertiesModal" tabindex="-1" aria-labelledby="ignoredPropertiesModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-lg">
+            <div class="modal-content p-4">
+                <div class="modal-header">
+                    <h5 class="modal-ignoredProperties" id="ignoredPropertiesModalLabel">Ignored properties</h5>
+                    <button type="button" class="btn-close" @click="resetForm" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="container-fluid">
+                        <div class="container list-view mb-3">
+                            <div v-for="(property, index) in settings.shape.ignoredProperties" :key="index" class="row">
+                                <div class="col-sm-10">
+                                    {{ getShorthandFromFullIri(property) }}
+                                </div>
+                                <div class="col-sm-2 pe-0 p-1 text-md-end">
+                                    <span class="btn btn-light btn-outline-dark ms-3 bi-trash" v-on:click="removeSettingRow('shape.ignoredProperties',index)"></span>
+                                </div>
+                            </div>
+                        </div>
+                        <id-field field="shape.ignoredProperties" fieldName="Property" altertype="add" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+<script lang="ts">
+  import {defineComponent, inject} from "vue";
+  import IdField from '../field/IdField.vue';
+  import {removeSettingRowKey, getShorthandFromFullIriKey} from "@/symbols/shape";
+
+  export default defineComponent({
+    components: {
+      IdField,
+    },
+    inject: ['settings'],
+    setup() {
+      const removeSettingRow = inject(removeSettingRowKey);
+      const getShorthandFromFullIri = inject(getShorthandFromFullIriKey);
+
+      if (removeSettingRow === undefined || getShorthandFromFullIriKey === undefined) {
+        throw new Error('Failed to inject function');
+      }
+
+      return {
+        removeSettingRow,
+        getShorthandFromFullIri,
+      };
+    },
+  });
+</script>

--- a/frontend/src/components/shape/modal/LabelModal.vue
+++ b/frontend/src/components/shape/modal/LabelModal.vue
@@ -19,7 +19,7 @@
                             <div class="col-sm-10">
                                 <select v-model="language" class="form-select" >
                                     <option v-for="(language, index) in shapeConfig.languages" :key="index" :value="index">
-                                        {{$t('language.'+language)}}
+                                        {{ language }}
                                     </option>
                                 </select>
                             </div>

--- a/frontend/src/components/shape/modal/PrefixModal.vue
+++ b/frontend/src/components/shape/modal/PrefixModal.vue
@@ -18,7 +18,7 @@
                         <div class="row mb-3">
                             <label class="col-sm-2 col-form-label">Path</label>
                             <div class="col-sm-10">
-                                <Field type="text" v-model="new_path" name="new-prefix-id" :rules="validateAbsoluteIRI" class="form-control" :placeholder="$t('iri')" />
+                                <Field type="text" v-model="new_path" name="new-prefix-id" :rules="validateAbsoluteIRI" class="form-control" placeholder="Iri" />
                                 <ErrorMessage name="new-prefix-id" class="error-message" />
                             </div>
                         </div>

--- a/frontend/src/components/shape/tab/PrefixTab.vue
+++ b/frontend/src/components/shape/tab/PrefixTab.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="scrollable-content">
         <div class="container list-view mb-3">
-            <div class="row d-none d-md-flex">
+            <div class="row d-none d-md-flex header-row">
                 <div class="col-md-2 small-form-label">
                     Prefix
                 </div>

--- a/frontend/src/components/shape/tab/PropertyTab.vue
+++ b/frontend/src/components/shape/tab/PropertyTab.vue
@@ -46,7 +46,7 @@
                                     <div class="row">
                                         <div class="col-12 col-lg-5">
                                             <div class="row">
-                                                <id-field :field="'property.'+property.key+'.path'" fieldName="sh:path" :value="property.path"  :inline="false" />
+                                                <id-field :field="'property.'+property.key+'.path'" fieldName="sh:path"  :inline="false" />
                                             </div>
                                         </div>
                                         <div class="col-12 col-lg-3">
@@ -66,10 +66,10 @@
                                             </div>
                                             <div class="row">
                                                 <div class="form-property col-6">
-                                                    <input type="number" v-model="property.minCount" class="form-control" :placeholder="0">
+                                                    <input type="number" v-model="property.minCount" class="form-control">
                                                 </div>
                                                 <div class="form-property col-6">
-                                                    <input type="number" v-model="property.maxCount" class="form-control" :placeholder="1">
+                                                    <input type="number" v-model="property.maxCount" class="form-control">
                                                 </div>
                                             </div>
                                         </div>

--- a/frontend/src/components/shape/tab/ShapeTab.vue
+++ b/frontend/src/components/shape/tab/ShapeTab.vue
@@ -1,5 +1,5 @@
 <template>
-    <id-field field="shape.id" :value="settings.shape.id" />
+    <id-field field="shape.id" />
     <label-field field="shape.label" :list="settings.shape.label" />
     <div class="row mb-3">
         <label class="col-sm-2 col-form-label">dc:identifier</label>
@@ -8,7 +8,7 @@
             <ErrorMessage name="dc_identifier" class="error-message" />
        </div>
     </div>
-    <id-field field="shape.targetClass" fieldName="sh:targetClass" :value="settings.shape.targetClass" />
+    <id-field field="shape.targetClass" fieldName="sh:targetClass" />
     <div class="row mb-3">
         <label class="col-sm-2 col-form-label">rdfs:comment</label>
         <div class="col-sm-10">

--- a/frontend/src/components/shape/tab/ShapeTab.vue
+++ b/frontend/src/components/shape/tab/ShapeTab.vue
@@ -17,6 +17,15 @@
     </div>
     <div class="row mb-3">
         <div class="col-sm-10 offset-sm-2">
+            <div class="form-check form-switch d-inline-block pt-1 pb-1">
+                <input class="form-check-input" v-model="settings.shape.closed" type="checkbox" id="flexSwitchCheckDefault" :checked="settings.shape.closed === true">
+                <label class="form-check-label" for="flexSwitchCheckDefault">{{ $t('isClosed') }}</label>
+            </div>
+            <button class="btn btn-light btn-outline-dark btn-sm ms-2 pe-2 pt-1 pb-1 ps-2" type="button" v-if="settings.shape.closed" data-bs-toggle="modal" data-bs-target="#ignoredPropertiesModal">Alter exceptions</button>
+        </div>
+    </div>
+    <div class="row mb-3">
+        <div class="col-sm-10 offset-sm-2">
             <div class="form-check form-switch">
                 <input class="form-check-input" v-model="settings.shape.memorixCompatible" type="checkbox" id="flexSwitchCheckDefault" :checked="settings.shape.memorixCompatible === true">
                 <label class="form-check-label" for="flexSwitchCheckDefault">{{ $t('memorixCompatible') }}</label>

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1,5 +1,6 @@
 {
   "welcome": "Welcome to",
+  "backendOff": "The backend is not online.",
   "functionalityForNow": "Functionality for now",
   "pickShapeText": "Which existing shape do you want to use.",
   "createNewShape": "Create new shape",

--- a/frontend/src/i18n/nl.json
+++ b/frontend/src/i18n/nl.json
@@ -1,5 +1,6 @@
 {
   "welcome": "Welkom bij",
+  "backendOff": "De backend is niet online.",
   "functionalityForNow": "Functionaliteit voor nu",
   "createNewShape": "Maak een shape",
   "pickShapeText": "Welke shape wil je gebruiken.",

--- a/frontend/src/i18n/nl.json
+++ b/frontend/src/i18n/nl.json
@@ -26,6 +26,7 @@
     "path" : "Property path"
   },
   "memorixCompatible" : "Shape is voor Memorix",
+  "isClosed": "Shape is closed",
   "nexttab" : "Volgende tab",
   "autofill" : "automatisch gevuld",
   "download" : "Download",
@@ -65,10 +66,6 @@
   "AddShape": "Shape toevoegen (ttl file)",
   "prefixNotFound": "Deze prefix is niet gevonden",
   "shapeIdRequired": "Om properties toe te voegen is een geldig id van de shape verplicht.",
-  "language": {
-    "Dutch" : "Nederlands",
-    "English" : "Engels"
-  },
   "button" : {
     "add" : "Toevoegen",
     "cancel" : "Annuleren"

--- a/frontend/src/styles/_listview.scss
+++ b/frontend/src/styles/_listview.scss
@@ -11,9 +11,10 @@
     }
   }
 }
+#ignoredPropertiesModal,
 #prefix {
   .list-view {
-    > .row:not(:first-child) {
+    > .row:not(.header-row) {
       border-top:1px solid #fff;
       border-bottom:1px solid #fff;
       &:hover {

--- a/frontend/src/symbols/shape.ts
+++ b/frontend/src/symbols/shape.ts
@@ -1,5 +1,5 @@
 import { InjectionKey } from "vue";
-import { UpdateSettingFieldFunction, AddSettingRowFunction, RemoveSettingRowFunction, GetFullIriFunction, FetchShapesFunction } from "@/types/shape";
+import { UpdateSettingFieldFunction, AddSettingRowFunction, RemoveSettingRowFunction, GetFullIriFunction, GetShorthandFromFullIriFunction, FetchShapesFunction } from "@/types/shape";
 
 export const updateSettingFieldKey: InjectionKey<UpdateSettingFieldFunction> = Symbol(
   "updateSettingField"
@@ -17,8 +17,13 @@ export const getFullIriKey: InjectionKey<GetFullIriFunction> = Symbol(
   "getFullIri"
 );
 
+export const getShorthandFromFullIriKey: InjectionKey<GetShorthandFromFullIriFunction> = Symbol(
+  "getShorthandFromFullIri"
+);
+
 export const fetchShapesKey: InjectionKey<FetchShapesFunction> = Symbol(
   "fetchShapes"
 );
+
 
 

--- a/frontend/src/types/shape.ts
+++ b/frontend/src/types/shape.ts
@@ -7,4 +7,6 @@ export type RemoveSettingRowFunction = (field: string, index: number) => void;
 
 export type GetFullIriFunction = (iri: string) => string;
 
+export type GetShorthandFromFullIriFunction = (iri: string) => string;
+
 export type FetchShapesFunction = () => void;


### PR DESCRIPTION
based on the presentation I made some small changes
- fixed lagging id fields (fixed before presentation, but now committed)
- don't try to translate languages. They come from config so can be set in user's language
- when backend is not running frontend gives a global message instead of just js errors
- added closed shape field (with extra ignoreProperties popup)