### PR TITLE
Add docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+node_modules
+
+# OS
+.DS_Store
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+dist

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ cd frontend
 npm run serve
 ```
 
+## Deploying with docker
+
+Alternatively you can also deploy the backend on http://localhost:3000, and the frontend on http://localhost:8080 with docker:
+
+```bash
+docker-compose up
+```
+
 ## Testing the backend
 
 ```bash

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,24 @@
+
+FROM node:14
+
+WORKDIR /app
+# ENV NODE_ENV production
+
+## TODO: It is recommended to create and use a non-root user
+# RUN addgroup --gid 1001 nodejs
+# RUN adduser --gid 1001 -u 1001 --disabled-password --shell /bin/bash nodejs
+# COPY . ./ 
+# RUN chown -R nodejs:nodejs /app
+# # COPY --from=deps --chown=nodejs:nodejs /app/node_modules ./node_modules
+# # COPY --from=build-react --chown=nodejs:nodejs /app/build ./public
+# USER nodejs
+
+COPY ./backend backend
+# COPY ./resources resources
+
+WORKDIR /app/backend
+
+RUN npm install
+
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 # USER nodejs
 
 COPY ./backend backend
-# COPY ./resources resources
+COPY ./resources resources
 
 WORKDIR /app/backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3"
+
+services:
+
+  backend:
+    build:
+      context: .
+      dockerfile: ./backend/Dockerfile
+    restart: unless-stopped
+    ports:
+      - 3000:3000
+    # entrypoint: tail -f /dev/null
+
+
+  frontend:
+    build:
+      context: .
+      dockerfile: ./frontend/Dockerfile
+      # args:
+      #   BACKEND_URL: ${BACKEND_URL-true}
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - 8080:8080
+    environment:
+      - BACKEND_URL=http://backend:3000
+    # entrypoint: tail -f /dev/null
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,12 @@ services:
     restart: unless-stopped
     ports:
       - 3000:3000
-    # entrypoint: tail -f /dev/null
 
 
   frontend:
     build:
       context: .
       dockerfile: ./frontend/Dockerfile
-      # args:
-      #   BACKEND_URL: ${BACKEND_URL-true}
     restart: unless-stopped
     depends_on:
       - backend
@@ -25,5 +22,3 @@ services:
       - 8080:8080
     environment:
       - BACKEND_URL=http://backend:3000
-    # entrypoint: tail -f /dev/null
-

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:14
+
+WORKDIR /app
+# ENV NODE_ENV production
+
+## TODO: It is recommended to create and use a non-root user
+# RUN addgroup --gid 1001 nodejs
+# RUN adduser --gid 1001 -u 1001 --disabled-password --shell /bin/bash nodejs
+# # COPY server.ts package.json ./ 
+# COPY . ./ 
+# RUN chown -R nodejs:nodejs /app
+# # COPY --from=deps --chown=nodejs:nodejs /app/node_modules ./node_modules
+# # COPY --from=build-react --chown=nodejs:nodejs /app/build ./public
+# USER nodejs
+
+
+COPY ./frontend frontend
+COPY ./resources resources
+
+WORKDIR /app/frontend
+
+
+RUN npm install
+
+
+EXPOSE 4000
+CMD ["npm", "run", "serve"]

--- a/frontend/src/helper.ts
+++ b/frontend/src/helper.ts
@@ -1,3 +1,3 @@
 export const server = {
-  baseURL: 'http://localhost:3000',
+  baseURL: process.env.BACKEND_URL || 'http://localhost:3000',
 }


### PR DESCRIPTION
This pull request add the files required to easily deploy LDShapes from the source code using `docker-compose`:

* `backend/Dockerfile`
* `frontend/Dockerfile`
* `docker-compose.yml`
* `.dockerignore`

I also made a change to the `helper.ts` file to get the backend URL from the `BACKEND_URL` environment variable (you might want to test this works properly with your local deployment)

And added instructions to deploy with `docker-compose up` in the `README.md`

Currently it is built to be able to quickly build and start LDShapes in docker containers, and avoid versioning errors (cf. https://github.com/picturae/ldshapes/issues/16). It could be improved to be more optimized for production deployments or development settings depending of the use people want to have with it
